### PR TITLE
Added file meta data hashing for large files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,3 @@ composer.lock
 phpunit.xml
 .php_cs.cache
 .idea
-tests/test.txt

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ vendor/
 composer.lock
 phpunit.xml
 .php_cs.cache
+.idea
+tests/test.txt

--- a/README.md
+++ b/README.md
@@ -50,6 +50,11 @@ changes producced in the filesystem. The `ResourceWatcherResult` class has the f
 * `getUpdatedFiles()`: Returns an array with the paths of the updated resources.
 * `hasChanges()`: Are they changes in your resources?.
 
+### Hashing alternatives
+Two hashing classes are included in the package: 
+* `Yosymfony\ResourceWatcher\Crc32ContentHash`, which hashes the content of the file
+* `Yosymfony\ResourceWatcher\Crc32MetaDataHash`, which hashes the filename and its last modified timestamp
+
 ### Rebuild cache
 
 To rebuild the resource cache uses `rebuild()` method of the class `ResourceWatcher`.

--- a/src/Crc32MetaDataHash.php
+++ b/src/Crc32MetaDataHash.php
@@ -12,18 +12,23 @@
 namespace Yosymfony\ResourceWatcher;
 
 /**
- * Interface for hashing content.
+ * CRC32 content hash implementation.
  *
  * @author Victor Puertas <vpgugr@gmail.com>
  */
-interface ContentHashInterface
+class Crc32MetaDataHash implements HashInterface
 {
     /**
-     * Calculates the hash of the content.
-     *
-     * @param string $content  Message to be hashed.
-     *
-     * @return string Returns a string containing the calculated message digest.
+     * {@inheritdoc}
      */
-    public function hash($content);
+    public function hash($filepath)
+    {
+        $name = basename($filepath);
+
+        $time = !is_dir($filepath)
+            ? filemtime($filepath)
+            : filemtime(rtrim($filepath . '/') . '/.');;
+
+        return hash('crc32', $name . $time);
+    }
 }

--- a/src/Crc32MetaDataHash.php
+++ b/src/Crc32MetaDataHash.php
@@ -18,17 +18,31 @@ namespace Yosymfony\ResourceWatcher;
  */
 class Crc32MetaDataHash implements HashInterface
 {
+    /** @var bool */
+    protected $clearStatCache;
+
+    /**
+     * Assign option to clear the file stat() cache.
+     * @param bool $clearStatCache
+     */
+    public function __construct($clearStatCache = false)
+    {
+        $this->clearStatCache = $clearStatCache;
+    }
+
     /**
      * {@inheritdoc}
      */
     public function hash($filepath)
     {
-        $name = basename($filepath);
+        if ($this->clearStatCache) {
+            clearstatcache(true, $filepath);
+        }
 
-        $time = !is_dir($filepath)
-            ? filemtime($filepath)
-            : filemtime(rtrim($filepath . '/') . '/.');;
+        $data = stat($filepath);
 
-        return hash('crc32', $name . $time);
+        $str = basename($filepath) . $data['size'] . $data['mtime'] . $data['mode'];
+
+        return hash('crc32', $str);
     }
 }

--- a/src/HashInterface.php
+++ b/src/HashInterface.php
@@ -12,23 +12,18 @@
 namespace Yosymfony\ResourceWatcher;
 
 /**
- * CRC32 content hash implementation.
+ * Interface for hashing a file.
  *
  * @author Victor Puertas <vpgugr@gmail.com>
  */
-class Crc32ContentHash implements HashInterface
+interface HashInterface
 {
     /**
-     * {@inheritdoc}
+     * Calculates the hash of a file.
+     *
+     * @param string $filepath
+     *
+     * @return string Returns a string containing the calculated message digest.
      */
-    public function hash($filepath)
-    {
-        $fileContent = $filepath;
-
-        if (!\is_dir($filepath)) {
-            $fileContent = file_get_contents($filepath);
-        }
-
-        return hash('crc32', $fileContent);
-    }
+    public function hash($filepath);
 }

--- a/src/ResourceWatcher.php
+++ b/src/ResourceWatcher.php
@@ -25,7 +25,7 @@ class ResourceWatcher
     private $isEnabledRelativePath = false;
     private $cache;
     private $finder;
-    private $contentHash;
+    private $hasher;
     private $fileHashesFromFinder = [];
     private $newFiles = [];
     private $deletedFiles = [];
@@ -36,13 +36,13 @@ class ResourceWatcher
      *
      * @param ResourceCacheInterface $resourceCache The cache.
      * @param Finder $finder The Symfony Finder.
-     * @param ContentHashInterface $contentHash The file hash strategy.
+     * @param HashInterface $hasher The file hash strategy.
      */
-    public function __construct(ResourceCacheInterface $resourceCache, Finder $finder, ContentHashInterface $contentHash)
+    public function __construct(ResourceCacheInterface $resourceCache, Finder $finder, HashInterface $hasher)
     {
         $this->cache = $resourceCache;
         $this->finder = $finder;
-        $this->contentHash = $contentHash;
+        $this->hasher = $hasher;
     }
 
     /**
@@ -199,27 +199,22 @@ class ResourceWatcher
     }
 
     /**
+     * @param $filename
      * @return string
      */
     private function calculateHashOfFile($filename)
     {
-        $fileContent = $filename;
-
-        if (!\is_dir($filename)) {
-            $fileContent = file_get_contents($filename);
-        }
-
-        return $this->contentHash->hash($fileContent);
+        return $this->hasher->hash($filename);
     }
 
     /**
+     * @param FinderFileInfo $file
      * @return string
      */
     private function getFilePathForCache(FinderFileInfo $file)
     {
         if ($this->isEnabledRelativePath === true) {
             return $file->getRelativePathname();
-            print "entraa!!!!\n";
         }
 
         return $file->getPathname();

--- a/tests/Crc32ContentHashTest.php
+++ b/tests/Crc32ContentHashTest.php
@@ -18,7 +18,7 @@ class Crc32ContentHashTest extends TestCase
 {
     public function testHashMustReturnTheContentDisgestWithCRC32()
     {
-        $filepath = __DIR__ . '/test.txt';
+        $filepath = sys_get_temp_dir() . '/test.txt';
 
         file_put_contents($filepath, 'acme');
 

--- a/tests/Crc32MetaDataHashTest.php
+++ b/tests/Crc32MetaDataHashTest.php
@@ -18,7 +18,7 @@ class Crc32MetaDataHashTest extends TestCase
 {
     public function testHashMustReturnTheMetaDataDigestWithCRC32()
     {
-        $filepath = __DIR__ . '/test.txt';
+        $filepath = sys_get_temp_dir() . '/test.txt';
 
         touch($filepath, strtotime('2020-05-25 17:42'));
 

--- a/tests/Crc32MetaDataHashTest.php
+++ b/tests/Crc32MetaDataHashTest.php
@@ -25,7 +25,7 @@ class Crc32MetaDataHashTest extends TestCase
         $crc32ContentHash = new Crc32MetaDataHash();
         $currentValue = $crc32ContentHash->hash($filepath);
 
-        $this->assertEquals('f91b448c', $currentValue);
+        $this->assertEquals('0b93d57a', $currentValue);
 
         unlink($filepath);
     }

--- a/tests/Crc32MetaDataHashTest.php
+++ b/tests/Crc32MetaDataHashTest.php
@@ -12,20 +12,20 @@
 namespace Yosymfony\ResourceWatcher\Tests;
 
 use PHPUnit\Framework\TestCase;
-use Yosymfony\ResourceWatcher\Crc32ContentHash;
+use Yosymfony\ResourceWatcher\Crc32MetaDataHash;
 
-class Crc32ContentHashTest extends TestCase
+class Crc32MetaDataHashTest extends TestCase
 {
-    public function testHashMustReturnTheContentDisgestWithCRC32()
+    public function testHashMustReturnTheMetaDataDigestWithCRC32()
     {
         $filepath = __DIR__ . '/test.txt';
 
-        file_put_contents($filepath, 'acme');
+        touch($filepath, strtotime('2020-05-25 17:42'));
 
-        $crc32ContentHash = new Crc32ContentHash();
+        $crc32ContentHash = new Crc32MetaDataHash();
         $currentValue = $crc32ContentHash->hash($filepath);
 
-        $this->assertEquals('8f7ecb57', $currentValue);
+        $this->assertEquals('f91b448c', $currentValue);
 
         unlink($filepath);
     }

--- a/tests/Crc32MetaDataHashTest.php
+++ b/tests/Crc32MetaDataHashTest.php
@@ -25,7 +25,11 @@ class Crc32MetaDataHashTest extends TestCase
         $crc32ContentHash = new Crc32MetaDataHash();
         $currentValue = $crc32ContentHash->hash($filepath);
 
-        $this->assertEquals('0b93d57a', $currentValue);
+        $fileData = stat($filepath);
+
+        $expected = basename($filepath) . $fileData['size'] . $fileData['mtime'] . $fileData['mode'];
+
+        $this->assertEquals(hash('crc32', $expected), $currentValue);
 
         unlink($filepath);
     }


### PR DESCRIPTION
Hello,
This PR allows working with large files by adding a new hashing class: `Crc32MetaDataHash`.
With this `ResourceWatcher` can be instantiated either with `Crc32ContentHash` or `Crc32MetaDataHash`. The latter doesn't load the whole file content into memory to create a hash. Instead, it uses `stat()` to generate the hash from the file's name, size, modified time and mode (chmod).