### PR TITLE
Fix exception if the constructor is called twice with the same file

### DIFF
--- a/src/ResourceCachePhpFile.php
+++ b/src/ResourceCachePhpFile.php
@@ -82,7 +82,7 @@ class ResourceCachePhpFile extends ResourceCacheMemory
             return;
         }
 
-        $fileContent = include_once($filename);
+        $fileContent = include($filename);
 
         if (is_array($fileContent) == false) {
             throw new \InvalidArgumentException('Cache file invalid format.');


### PR DESCRIPTION
If `new ResourceCachePhpFile()` is called twice with the same filename in different parts of the code, it will cause an ` InvalidArgumentException` because `include_once` returns `true` instead of an array the second time.

So it it safer to use `include` instead.