### PR TITLE
Escape single quotes in filenames

### DIFF
--- a/src/ResourceWatcher.php
+++ b/src/ResourceWatcher.php
@@ -213,10 +213,10 @@ class ResourceWatcher
      */
     private function getFilePathForCache(FinderFileInfo $file)
     {
-        if ($this->isEnabledRelativePath === true) {
-            return addslashes($file->getRelativePathname());
-        }
+        $path = $this->isEnabledRelativePath === true
+            ? $file->getRelativePathname()
+            : $file->getPathname();
 
-        return $file->getPathname();
+        return addslashes($path);
     }
 }

--- a/src/ResourceWatcher.php
+++ b/src/ResourceWatcher.php
@@ -214,7 +214,7 @@ class ResourceWatcher
     private function getFilePathForCache(FinderFileInfo $file)
     {
         if ($this->isEnabledRelativePath === true) {
-            return $file->getRelativePathname();
+            return addslashes($file->getRelativePathname());
         }
 
         return $file->getPathname();

--- a/tests/ResourceWatcherTest.php
+++ b/tests/ResourceWatcherTest.php
@@ -194,7 +194,7 @@ class ResourceWatcherTest extends TestCase
         $this->assertTrue(\strlen($cacheMemory->read($file)) > 0);
     }
 
-    private function makeResourceWatcher(Finder $finder)
+    protected function makeResourceWatcher(Finder $finder)
     {
         $cacheMemory = new ResourceCacheMemory();
         $contentHashCrc32 = new Crc32ContentHash();

--- a/tests/ResourceWatcherWithPhpFileTest.php
+++ b/tests/ResourceWatcherWithPhpFileTest.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * This file is part of the Yo! Symfony Resource Watcher.
+ *
+ * (c) YoSymfony <http://github.com/yosymfony>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Yosymfony\ResourceWatcher\Tests;
+
+use Symfony\Component\Finder\Finder;
+use Yosymfony\ResourceWatcher\Crc32ContentHash;
+use Yosymfony\ResourceWatcher\ResourceCachePhpFile;
+use Yosymfony\ResourceWatcher\ResourceWatcher;
+
+class ResourceWatcherWithPhpFileTest extends ResourceWatcherTest
+{
+    public function testFindChangesMustCatchFilesWithAccents()
+    {
+        $filepath = $this->tmpDir . "/file1 - O'Connor.txt";
+        $finder = new Finder();
+        $finder->files()
+            ->name('*.txt')
+            ->in($this->tmpDir);
+
+        $resourceWatcher = $this->makeResourceWatcher($finder);
+        $resourceWatcher->findChanges();
+
+        $this->fs->dumpFile($filepath, 'test');
+        $result = $resourceWatcher->findChanges();
+
+        $this->assertCount(1, $result->getNewFiles());
+
+
+        $this->fs->remove($filepath);
+        $result = $resourceWatcher->findChanges();
+        $this->assertCount(1, $result->getDeletedFiles());
+    }
+
+    protected function makeResourceWatcher(Finder $finder)
+    {
+        $cacheFile = sys_get_temp_dir() . '/resource-watcher-cache.php';
+
+        if (file_exists($cacheFile)) {
+            unlink($cacheFile);
+        }
+
+        $cacheMemory = new ResourceCachePhpFile($cacheFile);
+        $contentHashCrc32 = new Crc32ContentHash();
+
+        return new ResourceWatcher($cacheMemory, $finder, $contentHashCrc32);
+    }
+}


### PR DESCRIPTION
This is a quick fix - the point is to prevent syntax errors in the generated cache file when the filename contains a single quote.
Not sure what effect this will have on the `ResourceWatcher::calculateHashOfFile()` method.