### PR TITLE
fix: symfony/finder version conflict in spatie/phpunit-watcher and type hint Unit tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ php:
   - 7.2
   - 7.3
   - 7.4
+  - 8.0
+  - 8.1
 
 before_script:
   - composer self-update

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,12 @@
 {
-    "name":"yosymfony/resource-watcher",
+    "name": "yosymfony/resource-watcher",
     "description": "A simple resource watcher using Symfony Finder",
-    "keywords": ["resources","watcher","finder","symfony"],
+    "keywords": [
+        "resources",
+        "watcher",
+        "finder",
+        "symfony"
+    ],
     "license": "MIT",
     "homepage": "http://yosymfony.com",
     "authors": [
@@ -12,7 +17,7 @@
     ],
     "require": {
         "php": ">=5.6",
-        "symfony/finder": "^2.7|^3.0|^4.0|^5.0"
+        "symfony/finder": "^2.7|^3.0|^4.0|^5.0|^6.0"
     },
     "require-dev": {
         "symfony/filesystem": "^2.7|^3.0|^4.0|^5.0",

--- a/tests/Crc32ContentHashTest.php
+++ b/tests/Crc32ContentHashTest.php
@@ -16,7 +16,7 @@ use Yosymfony\ResourceWatcher\Crc32ContentHash;
 
 class Crc32ContentHashTest extends TestCase
 {
-    public function testHashMustReturnTheContentDisgestWithCRC32()
+    public function testHashMustReturnTheContentDisgestWithCRC32(): void
     {
         $filepath = sys_get_temp_dir() . '/test.txt';
 

--- a/tests/Crc32MetaDataHashTest.php
+++ b/tests/Crc32MetaDataHashTest.php
@@ -16,7 +16,7 @@ use Yosymfony\ResourceWatcher\Crc32MetaDataHash;
 
 class Crc32MetaDataHashTest extends TestCase
 {
-    public function testHashMustReturnTheMetaDataDigestWithCRC32()
+    public function testHashMustReturnTheMetaDataDigestWithCRC32(): void
     {
         $filepath = sys_get_temp_dir() . '/test.txt';
 

--- a/tests/ResourceCacheMemoryTest.php
+++ b/tests/ResourceCacheMemoryTest.php
@@ -18,31 +18,31 @@ class ResourceCacheMemoryTest extends TestCase
 {
     private $cache;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->cache = new ResourceCacheMemory();
     }
 
-    public function testIsInitializedMustReturnFalseInTheInitialState()
+    public function testIsInitializedMustReturnFalseInTheInitialState(): void
     {
         $this->assertFalse($this->cache->isInitialized());
     }
 
-    public function testIsInitializedMustReturnTrueAfterSave()
+    public function testIsInitializedMustReturnTrueAfterSave(): void
     {
         $this->cache->save();
 
         $this->assertTrue($this->cache->isInitialized());
     }
 
-    public function testGetAllMustReturnAllFilesInCache()
+    public function testGetAllMustReturnAllFilesInCache(): void
     {
         $this->cache->write('/my-path/file1.txt', '2442345');
 
         $this->assertCount(1, $this->cache->getAll());
     }
 
-    public function testReadMustReturnTheHashOfTheFile()
+    public function testReadMustReturnTheHashOfTheFile(): void
     {
         $hash = 'a54ffa';
         $this->cache->write('/my-path/file1.txt', $hash);
@@ -50,7 +50,7 @@ class ResourceCacheMemoryTest extends TestCase
         $this->assertEquals($hash, $this->cache->read('/my-path/file1.txt'));
     }
 
-    public function testWriteMustAddANewFile()
+    public function testWriteMustAddANewFile(): void
     {
         $hash = 'a54ffa';
         $this->cache->write('/my-path/file1.txt', $hash);
@@ -58,7 +58,7 @@ class ResourceCacheMemoryTest extends TestCase
         $this->assertEquals($hash, $this->cache->read('/my-path/file1.txt'));
     }
 
-    public function testWriteMustUpdateAFilePreviouslyAdded()
+    public function testWriteMustUpdateAFilePreviouslyAdded(): void
     {
         $hash = 'b54ffb';
         $file = '/my-path/file1.txt';
@@ -68,7 +68,7 @@ class ResourceCacheMemoryTest extends TestCase
         $this->assertEquals($hash, $this->cache->read('/my-path/file1.txt'));
     }
 
-    public function testEraseMustDeleteAllFiles()
+    public function testEraseMustDeleteAllFiles(): void
     {
         $this->cache->write('/my-path/file1.txt', 'a54ffa');
         $this->cache->erase();
@@ -76,7 +76,7 @@ class ResourceCacheMemoryTest extends TestCase
         $this->assertCount(0, $this->cache->getAll());
     }
 
-    public function testDeleteMustDeleteTheFileIndicated()
+    public function testDeleteMustDeleteTheFileIndicated(): void
     {
         $file = '/my-path/file1.txt';
         $this->cache->write($file, 'a54ffa');

--- a/tests/ResourceCachePhpFileTest.php
+++ b/tests/ResourceCachePhpFileTest.php
@@ -21,7 +21,7 @@ class ResourceCachePhpFileTest extends TestCase
     private $fs;
     private $tmpDir;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->tmpDir = sys_get_temp_dir() . '/resource-watchers-tests';
         $this->cacheFile = $this->tmpDir . '/cache-file-test.php';
@@ -29,19 +29,19 @@ class ResourceCachePhpFileTest extends TestCase
         $this->fs->mkdir($this->tmpDir);
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         $this->fs->remove($this->tmpDir);
     }
 
-    public function testIsInitializedMustReturnFalseWhenTheCacheFileIsNotExists()
+    public function testIsInitializedMustReturnFalseWhenTheCacheFileIsNotExists(): void
     {
         $resourceCache = new ResourceCachePhpFile($this->cacheFile);
 
         $this->assertFalse($resourceCache->isInitialized());
     }
 
-    public function testIsInitializedMustReturnTrueWhenTheCacheIsSavedInTheCacheFile()
+    public function testIsInitializedMustReturnTrueWhenTheCacheIsSavedInTheCacheFile(): void
     {
         $resourceCache = new ResourceCachePhpFile($this->cacheFile);
         $resourceCache->save();
@@ -49,7 +49,7 @@ class ResourceCachePhpFileTest extends TestCase
         $this->assertTrue($resourceCache->isInitialized());
     }
 
-    public function testIsInitializedMustReturnTrueWhenThereIsAValidCacheFile()
+    public function testIsInitializedMustReturnTrueWhenThereIsAValidCacheFile(): void
     {
         $this->fs->dumpFile($this->cacheFile, "<?php\nreturn [];");
         $resourceCache = new ResourceCachePhpFile($this->cacheFile);
@@ -57,7 +57,7 @@ class ResourceCachePhpFileTest extends TestCase
         $this->assertTrue($resourceCache->isInitialized());
     }
 
-    public function testSaveMustDumpTheContentCacheInAFile()
+    public function testSaveMustDumpTheContentCacheInAFile(): void
     {
         $resourceCache = new ResourceCachePhpFile($this->cacheFile);
         $filename = 'file1.md';
@@ -74,7 +74,7 @@ class ResourceCachePhpFileTest extends TestCase
      * @expectedException InvalidArgumentException
      * @expectedExceptionMessage Cache file invalid format.
      */
-    public function testConstructWithAInvalidCacheFileMustThrownAnException()
+    public function testConstructWithAInvalidCacheFileMustThrownAnException(): void
     {
         $this->fs->dumpFile($this->cacheFile, '');
 
@@ -85,7 +85,7 @@ class ResourceCachePhpFileTest extends TestCase
      * @expectedException InvalidArgumentException
      * @expectedExceptionMessage The cache filename must ends with the extension ".php".
      */
-    public function testConstructWithANoPhpFileExtensionMustThrownAnException()
+    public function testConstructWithANoPhpFileExtensionMustThrownAnException(): void
     {
         $rc = new ResourceCachePhpFile($this->tmpDir . '/cache-file-test.txt');
     }

--- a/tests/ResourceWatcherResultTest.php
+++ b/tests/ResourceWatcherResultTest.php
@@ -21,7 +21,7 @@ class ResourceWatcherResultTests extends TestCase
     private $updatedFiles;
     private $resourceWatcherResult;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->newFiles = ['/my-path/newfile.txt'];
         $this->deletedFiles = ['/my-path/deletedfile.txt'];
@@ -33,49 +33,49 @@ class ResourceWatcherResultTests extends TestCase
         );
     }
 
-    public function testHasChangesMustReturnTrueWhenExistsNewFiles()
+    public function testHasChangesMustReturnTrueWhenExistsNewFiles(): void
     {
         $resourceWatcherResult = new ResourceWatcherResult($this->newFiles, [], []);
 
         $this->assertTrue($resourceWatcherResult->hasChanges());
     }
 
-    public function testHasChangesMustReturnTrueWhenExistsDeletedFiles()
+    public function testHasChangesMustReturnTrueWhenExistsDeletedFiles(): void
     {
         $resourceWatcherResult = new ResourceWatcherResult([], $this->deletedFiles, []);
 
         $this->assertTrue($resourceWatcherResult->hasChanges());
     }
 
-    public function testHasChangesMustReturnTrueWhenExistsUpdatedFiles()
+    public function testHasChangesMustReturnTrueWhenExistsUpdatedFiles(): void
     {
         $resourceWatcherResult = new ResourceWatcherResult([], [], $this->updatedFiles);
 
         $this->assertTrue($resourceWatcherResult->hasChanges());
     }
 
-    public function testHasChangesMustReturnFalseWhenDoesNotExistsChanges()
+    public function testHasChangesMustReturnFalseWhenDoesNotExistsChanges(): void
     {
         $resourceWatcherResult = new ResourceWatcherResult([], [], []);
 
         $this->assertFalse($resourceWatcherResult->hasChanges());
     }
 
-    public function testGetNewFilesMustReturnTheNewFiles()
+    public function testGetNewFilesMustReturnTheNewFiles(): void
     {
         $files = $this->resourceWatcherResult->getNewFiles();
         $this->assertCount(1, $files);
         $this->assertEquals('/my-path/newfile.txt', $files[0]);
     }
 
-    public function testGetDeletedFilesMustReturnTheDeletedFiles()
+    public function testGetDeletedFilesMustReturnTheDeletedFiles(): void
     {
         $files = $this->resourceWatcherResult->getDeletedFiles();
         $this->assertCount(1, $files);
         $this->assertEquals('/my-path/deletedfile.txt', $files[0]);
     }
 
-    public function testGetUpdatedFilesMustReturnTheDeletedFiles()
+    public function testGetUpdatedFilesMustReturnTheDeletedFiles(): void
     {
         $files = $this->resourceWatcherResult->getUpdatedFiles();
         $this->assertCount(1, $files);

--- a/tests/ResourceWatcherTest.php
+++ b/tests/ResourceWatcherTest.php
@@ -23,7 +23,7 @@ class ResourceWatcherTest extends TestCase
     protected $tmpDir;
     protected $fs;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->tmpDir = sys_get_temp_dir() . '/resourceWatcher-tests';
         $this->fs = new Filesystem();
@@ -31,12 +31,12 @@ class ResourceWatcherTest extends TestCase
         $this->fs->mkdir($this->tmpDir);
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         $this->fs->remove($this->tmpDir);
     }
 
-    public function testInitializeMustWarmUpTheCacheInCaseItIsCold()
+    public function testInitializeMustWarmUpTheCacheInCaseItIsCold(): void
     {
         $finder = new Finder();
         $finder->files()
@@ -50,7 +50,7 @@ class ResourceWatcherTest extends TestCase
         $this->assertTrue($cacheMemory->isInitialized());
     }
 
-    public function testHasChangesMustReturnFalseWithColdCache()
+    public function testHasChangesMustReturnFalseWithColdCache(): void
     {
         $finder = new Finder();
         $finder->files()
@@ -63,7 +63,7 @@ class ResourceWatcherTest extends TestCase
         $this->assertFalse($result->hasChanges());
     }
 
-    public function testHasChangesMustReturnTrueWhenNewFile()
+    public function testHasChangesMustReturnTrueWhenNewFile(): void
     {
         $finder = new Finder();
         $finder->files()
@@ -78,7 +78,7 @@ class ResourceWatcherTest extends TestCase
         $this->assertTrue($result->hasChanges());
     }
 
-    public function testHasChangesMustReturnFalseAfterRebuildCache()
+    public function testHasChangesMustReturnFalseAfterRebuildCache(): void
     {
         $finder = new Finder();
         $finder->files()
@@ -94,7 +94,7 @@ class ResourceWatcherTest extends TestCase
         $this->assertFalse($result->hasChanges());
     }
 
-    public function testFindChangesMustReturnANewFileWhenItIsCreated()
+    public function testFindChangesMustReturnANewFileWhenItIsCreated(): void
     {
         $finder = new Finder();
         $finder->files()
@@ -109,7 +109,7 @@ class ResourceWatcherTest extends TestCase
         $this->assertCount(1, $result->getNewFiles());
     }
 
-    public function testFindChangesMustReturnADeletedFileWhenItIsDeleted()
+    public function testFindChangesMustReturnADeletedFileWhenItIsDeleted(): void
     {
         $finder = new Finder();
         $finder->files()
@@ -125,7 +125,7 @@ class ResourceWatcherTest extends TestCase
         $this->assertCount(1, $result->getDeletedFiles());
     }
 
-    public function testFindChangesMustReturnAUpdatedFileWhenItIsModified()
+    public function testFindChangesMustReturnAUpdatedFileWhenItIsModified(): void
     {
         $filename = $this->tmpDir . '/file1.txt';
         $finder = new Finder();
@@ -142,7 +142,7 @@ class ResourceWatcherTest extends TestCase
         $this->assertCount(1, $result->getUpdatedFiles());
     }
 
-    public function testFindChangesMustReturnANewFileWhenANewDirectoryIsCreated()
+    public function testFindChangesMustReturnANewFileWhenANewDirectoryIsCreated(): void
     {
         $finder = new Finder();
         $finder->in($this->tmpDir);
@@ -157,10 +157,10 @@ class ResourceWatcherTest extends TestCase
         $this->assertEquals($this->tmpDir . '/dir-test', $newFiles[0]);
     }
 
-    public function testFindChangesMustUsesTheRelativePathWithTheCacheWhenEnableRelativePath()
+    public function testFindChangesMustUsesTheRelativePathWithTheCacheWhenEnableRelativePath(): void
     {
         $filename = 'file1.txt';
-        $file = $this->tmpDir . '/'.$filename;
+        $file = $this->tmpDir . '/' . $filename;
         $cacheMemory = new ResourceCacheMemory();
         $contentHashCrc32 = new Crc32ContentHash();
         $this->fs->dumpFile($file, 'test');
@@ -176,10 +176,10 @@ class ResourceWatcherTest extends TestCase
         $this->assertTrue(\strlen($cacheMemory->read($file)) == 0);
     }
 
-    public function testFindChangesMustUsesThePathWithTheCacheWhenIsNotEnabledTheRelativePath()
+    public function testFindChangesMustUsesThePathWithTheCacheWhenIsNotEnabledTheRelativePath(): void
     {
         $filename = 'file1.txt';
-        $file = $this->tmpDir . '/'.$filename;
+        $file = $this->tmpDir . '/' . $filename;
         $cacheMemory = new ResourceCacheMemory();
         $contentHashCrc32 = new Crc32ContentHash();
         $this->fs->dumpFile($file, 'test');
@@ -194,7 +194,7 @@ class ResourceWatcherTest extends TestCase
         $this->assertTrue(\strlen($cacheMemory->read($file)) > 0);
     }
 
-    private function makeResourceWatcher(Finder $finder)
+    private function makeResourceWatcher(Finder $finder): ResourceWatcher
     {
         $cacheMemory = new ResourceCacheMemory();
         $contentHashCrc32 = new Crc32ContentHash();


### PR DESCRIPTION
Fix: symfony/finder version conflict with spatie/phpunit-watcher dependencies and type hint Unit tests

[x] Bugfix (non-breaking change which fixes an issue)